### PR TITLE
Update kernelEntry.asm

### DIFF
--- a/kernel/src/kernelEntry.asm
+++ b/kernel/src/kernelEntry.asm
@@ -1,4 +1,4 @@
-section .text    
+;;section .text    
     [bits 32]
     [extern _start]
 


### PR DESCRIPTION
section .text only needed if there is a .data or something along those lines which is why its a comment just in case you want to add it back later